### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Go Build and Test
+permissions:
+  contents: read
 
 # NOTE: Runs on the latest commit on each push to a branch
 on: [push]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Go Build and Test
 permissions:
   contents: read
+  actions: write
 
 # NOTE: Runs on the latest commit on each push to a branch
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/TheJumpCloud/jc-aws-group-reconciler/security/code-scanning/1](https://github.com/TheJumpCloud/jc-aws-group-reconciler/security/code-scanning/1)

To resolve the issue, you should add a `permissions` block to the workflow, restricting the default permissions granted to the job(s). Based on the nature of the actions (building and testing code), the only required permission is usually to read repository contents. The best fix is to add the minimal block `permissions: contents: read` to the top level of the workflow file, above the `jobs:` definition. This will apply to all jobs in this workflow (you could also apply it per job, but here a workflow-wide block is most straightforward).

**Changes to make:**  
- Edit `.github/workflows/build.yml`
- Insert the block:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name:` and before `on:` (usually for clarity, directly after the workflow name).

No imports, definitions, or changes to existing steps are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
